### PR TITLE
delete plot(g)

### DIFF
--- a/R/propdViz.R
+++ b/R/propdViz.R
@@ -76,9 +76,6 @@ setMethod("plot", signature(x = "propd", y = "missing"),
               coords <- igraph::layout_with_fr(g, dim = 3)
               suppressWarnings(igraph::rglplot(g, layout = coords))
 
-            }else{
-
-              plot(g)
             }
 
             return(g)
@@ -232,9 +229,6 @@ geyser <- function(object, cutoff = 1000, k = 5, prompt = TRUE, plotly = FALSE){
     packageCheck("plotly")
     return(plotly::ggplotly(g))
 
-  }else{
-
-    plot(g)
   }
 
   return(g)
@@ -275,9 +269,6 @@ bowtie <- function(object, cutoff = 1000, k = 5, prompt = TRUE, plotly = FALSE){
     packageCheck("plotly")
     return(plotly::ggplotly(g))
 
-  }else{
-
-    plot(g)
   }
 
   return(g)
@@ -315,9 +306,6 @@ gemini <- function(object, cutoff = 1000, k = 5, prompt = TRUE, plotly = FALSE){
     packageCheck("plotly")
     return(plotly::ggplotly(g))
 
-  }else{
-
-    plot(g)
   }
 
   return(g)
@@ -379,9 +367,6 @@ slice <- function(object, cutoff = 1000, reference, prompt = TRUE, plotly = FALS
     packageCheck("plotly")
     return(plotly::ggplotly(g))
 
-  }else{
-
-    plot(g)
   }
 
   return(g)

--- a/R/proprViz.R
+++ b/R/proprViz.R
@@ -169,9 +169,6 @@ smear <- function(rho, prompt = TRUE, plotly = FALSE){
 
     return(plotly::ggplotly(g))
 
-  }else{
-
-    plot(g)
   }
 
   return(g)
@@ -526,7 +523,6 @@ mds <- function(rho, group, prompt = TRUE, plotly = FALSE){
     g <- g + ggplot2::geom_text(
       ggplot2::aes_string(x = "PC1", y = "PC2", label = "ID", colour = "Group"),
       data = df, size = 3, vjust = -1)
-    plot(g)
   }
 
   return(g)


### PR DESCRIPTION
`plot(g)` creates a redundant plot in addition to the one created by `return(g)`

See this notebook for an example of the problem:

https://gist.github.com/slowkow/4648559c42c0ee7a6c27e497e185d8c6

I re-ran the notebook after applying the changes in this pull request, and the duplicated plot has disappeared.