### PR TITLE
Fixing integer overflows

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2,6 +2,7 @@
 // Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #include <Rcpp.h>
+#include <stdint.h>
 
 using namespace Rcpp;
 
@@ -41,13 +42,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // covRcpp
-NumericMatrix covRcpp(NumericMatrix& X, const int norm_type);
+NumericMatrix covRcpp(NumericMatrix& X, const int32_t norm_type);
 RcppExport SEXP _propr_covRcpp(SEXP XSEXP, SEXP norm_typeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix& >::type X(XSEXP);
-    Rcpp::traits::input_parameter< const int >::type norm_type(norm_typeSEXP);
+    Rcpp::traits::input_parameter< const int32_t >::type norm_type(norm_typeSEXP);
     rcpp_result_gen = Rcpp::wrap(covRcpp(X, norm_type));
     return rcpp_result_gen;
 END_RCPP
@@ -75,13 +76,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // alrRcpp
-NumericMatrix alrRcpp(NumericMatrix& X, const int ivar);
+NumericMatrix alrRcpp(NumericMatrix& X, const int32_t ivar);
 RcppExport SEXP _propr_alrRcpp(SEXP XSEXP, SEXP ivarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix& >::type X(XSEXP);
-    Rcpp::traits::input_parameter< const int >::type ivar(ivarSEXP);
+    Rcpp::traits::input_parameter< const int32_t >::type ivar(ivarSEXP);
     rcpp_result_gen = Rcpp::wrap(alrRcpp(X, ivar));
     return rcpp_result_gen;
 END_RCPP
@@ -110,20 +111,20 @@ BEGIN_RCPP
 END_RCPP
 }
 // rhoRcpp
-NumericMatrix rhoRcpp(NumericMatrix X, NumericMatrix lr, const int ivar);
+NumericMatrix rhoRcpp(NumericMatrix X, NumericMatrix lr, const int32_t ivar);
 RcppExport SEXP _propr_rhoRcpp(SEXP XSEXP, SEXP lrSEXP, SEXP ivarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type X(XSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type lr(lrSEXP);
-    Rcpp::traits::input_parameter< const int >::type ivar(ivarSEXP);
+    Rcpp::traits::input_parameter< const int32_t >::type ivar(ivarSEXP);
     rcpp_result_gen = Rcpp::wrap(rhoRcpp(X, lr, ivar));
     return rcpp_result_gen;
 END_RCPP
 }
 // indexPairs
-std::vector<int> indexPairs(NumericMatrix& X, const String op, const double ref);
+std::vector<int32_t> indexPairs(NumericMatrix& X, const String op, const double ref);
 RcppExport SEXP _propr_indexPairs(SEXP XSEXP, SEXP opSEXP, SEXP refSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -136,26 +137,26 @@ BEGIN_RCPP
 END_RCPP
 }
 // indexToCoord
-List indexToCoord(IntegerVector V, const int N);
+List indexToCoord(IntegerVector V, const int32_t N);
 RcppExport SEXP _propr_indexToCoord(SEXP VSEXP, SEXP NSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< IntegerVector >::type V(VSEXP);
-    Rcpp::traits::input_parameter< const int >::type N(NSEXP);
+    Rcpp::traits::input_parameter< const int32_t >::type N(NSEXP);
     rcpp_result_gen = Rcpp::wrap(indexToCoord(V, N));
     return rcpp_result_gen;
 END_RCPP
 }
 // coordToIndex
-IntegerVector coordToIndex(IntegerVector row, IntegerVector col, const int N);
+IntegerVector coordToIndex(IntegerVector row, IntegerVector col, const int32_t N);
 RcppExport SEXP _propr_coordToIndex(SEXP rowSEXP, SEXP colSEXP, SEXP NSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< IntegerVector >::type row(rowSEXP);
     Rcpp::traits::input_parameter< IntegerVector >::type col(colSEXP);
-    Rcpp::traits::input_parameter< const int >::type N(NSEXP);
+    Rcpp::traits::input_parameter< const int32_t >::type N(NSEXP);
     rcpp_result_gen = Rcpp::wrap(coordToIndex(row, col, N));
     return rcpp_result_gen;
 END_RCPP
@@ -195,12 +196,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // labRcpp
-List labRcpp(int nfeats);
+List labRcpp(int32_t nfeats);
 RcppExport SEXP _propr_labRcpp(SEXP nfeatsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< int >::type nfeats(nfeatsSEXP);
+    Rcpp::traits::input_parameter<int32_t>::type nfeats(nfeatsSEXP);
     rcpp_result_gen = Rcpp::wrap(labRcpp(nfeats));
     return rcpp_result_gen;
 END_RCPP
@@ -239,7 +240,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // count_if
-int count_if(LogicalVector x);
+int32_t count_if(LogicalVector x);
 RcppExport SEXP _propr_count_if(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <math.h>
+#include <stdint.h>
 #include "backend.h"
 using namespace Rcpp;
 
@@ -23,8 +24,8 @@ double wtvRcpp(NumericVector x,
 // Function for centering matrix (via: correlateR package)
 NumericMatrix centerNumericMatrix(NumericMatrix & X){
 
-  const int m = X.ncol();
-  for (int j = 0; j < m; ++j) {
+  const int32_t m = X.ncol();
+  for (int32_t j = 0; j < m; ++j) {
     X(_, j) = X(_, j) - mean(X(_, j));
   }
 
@@ -35,21 +36,21 @@ NumericMatrix centerNumericMatrix(NumericMatrix & X){
 // [[Rcpp::export]]
 NumericMatrix corRcpp(NumericMatrix & X){
 
-  const int m = X.ncol();
+  const int32_t m = X.ncol();
 
   // Centering the matrix
   X = centerNumericMatrix(X);
 
   // Compute 1 over the sample standard deviation
   NumericVector inv_sqrt_ss(m);
-  for (int i = 0; i < m; ++i) {
+  for (int32_t i = 0; i < m; ++i) {
     inv_sqrt_ss(i) = 1 / sqrt(sum(X(_, i) * X(_, i)));
   }
 
   // Computing the correlation matrix
   NumericMatrix cor(m, m);
-  for (int i = 0; i < m; ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (int32_t i = 0; i < m; ++i) {
+    for (int32_t j = 0; j <= i; ++j) {
       cor(i, j) = sum(X(_,i) * X(_,j)) *
         inv_sqrt_ss(i) * inv_sqrt_ss(j);
       cor(j, i) = cor(i, j);
@@ -64,17 +65,17 @@ NumericMatrix corRcpp(NumericMatrix & X){
 NumericMatrix covRcpp(NumericMatrix & X,
                       const int norm_type = 0){
 
-  const int n = X.nrow();
-  const int m = X.ncol();
-  const int df = n - 1 + norm_type;
+  const int32_t n = X.nrow();
+  const int32_t m = X.ncol();
+  const int32_t df = n - 1 + norm_type;
 
   // Centering the matrix
   X = centerNumericMatrix(X);
 
   // Computing the covariance matrix
   NumericMatrix cov(m, m);
-  for (int i = 0; i < m; ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (int32_t i = 0; i < m; ++i) {
+    for (int32_t j = 0; j <= i; ++j) {
       cov(i, j) = sum(X(_, i) * X(_, j)) / df;
       cov(j, i) = cov(i, j);
     }
@@ -88,11 +89,11 @@ NumericMatrix covRcpp(NumericMatrix & X,
 NumericMatrix vlrRcpp(NumericMatrix & X){
 
   // Define total number of features
-  int nfeats = X.ncol();
+  int32_t nfeats = X.ncol();
 
   // Take log of "count matrix"
-  for(int i = 0; i < X.nrow(); i++){
-    for(int j = 0; j < nfeats; j++){
+  for(int32_t i = 0; i < X.nrow(); i++){
+    for(int32_t j = 0; j < nfeats; j++){
       X(i, j) = log(X(i, j));
     }
   }
@@ -102,13 +103,13 @@ NumericMatrix vlrRcpp(NumericMatrix & X){
 
   // Find diagonal
   NumericVector diag(nfeats);
-  for(int j = 0; j < nfeats; j++){
+  for(int32_t j = 0; j < nfeats; j++){
     diag[j] = X(j, j);
   }
 
   // Calculate vlr
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nfeats; j++){
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nfeats; j++){
       X(i, j) = -2 * X(i, j) + diag[i] + diag[j];
     }
   }
@@ -121,8 +122,8 @@ NumericMatrix vlrRcpp(NumericMatrix & X){
 NumericMatrix clrRcpp(NumericMatrix & X){
 
   // Take log of "count matrix"
-  for(int i = 0; i < X.nrow(); i++){
-    for(int j = 0; j < X.ncol(); j++){
+  for(int32_t i = 0; i < X.nrow(); i++){
+    for(int32_t j = 0; j < X.ncol(); j++){
       X(i, j) = log(X(i, j));
     }
 
@@ -136,7 +137,7 @@ NumericMatrix clrRcpp(NumericMatrix & X){
 // Function for alr
 // [[Rcpp::export]]
 NumericMatrix alrRcpp(NumericMatrix & X,
-                      const int ivar = 0){
+                      const int32_t ivar = 0){
 
   if(ivar == 0){
 
@@ -144,8 +145,8 @@ NumericMatrix alrRcpp(NumericMatrix & X,
   }
 
   // Take log of "count matrix"
-  for(int i = 0; i < X.nrow(); i++){
-    for(int j = 0; j < X.ncol(); j++){
+  for(int32_t i = 0; i < X.nrow(); i++){
+    for(int32_t j = 0; j < X.ncol(); j++){
       X(i, j) = log(X(i, j));
     }
 
@@ -160,8 +161,8 @@ NumericMatrix alrRcpp(NumericMatrix & X,
 // [[Rcpp::export]]
 NumericMatrix symRcpp(NumericMatrix & X){
 
-  for(int i = 1; i < X.nrow(); i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < X.nrow(); i++){
+    for(int32_t j = 0; j < i; j++){
       X(j, i) = X(i, j);
     }
   }
@@ -180,9 +181,9 @@ NumericMatrix phiRcpp(NumericMatrix X,
 
   // Make clr from "count matrix" X
   NumericMatrix clr = clrRcpp(X);
-  int nsubjs = clr.nrow();
+  int32_t nsubjs = clr.nrow();
 
-  for(int i = 0; i < mat.ncol(); i++){
+  for(int32_t i = 0; i < mat.ncol(); i++){
 
     // Calculate variance of the i-th clr composition
     double vari = sum(pow(clr(_, i) - mean(clr(_, i)), 2.0)) / (nsubjs - 1);
@@ -203,23 +204,23 @@ NumericMatrix phiRcpp(NumericMatrix X,
 // [[Rcpp::export]]
 NumericMatrix rhoRcpp(NumericMatrix X,
                       NumericMatrix lr,
-                      const int ivar = 0){
+                      const int32_t ivar = 0){
 
   // Make vlr from "count matrix" X (using a copy)
   NumericMatrix counts = clone(X);
   NumericMatrix mat = vlrRcpp(counts);
-  int nsubjs = X.nrow();
-  int nfeats = X.ncol();
+  int32_t nsubjs = X.nrow();
+  int32_t nfeats = X.ncol();
 
   // Calculate variance of the i-th clr composition
   NumericVector vars(nfeats);
-  for(int i = 0; i < nfeats; i++){
+  for(int32_t i = 0; i < nfeats; i++){
 
     vars[i] = sum(pow(lr(_, i) - mean(lr(_, i)), 2.0)) / (nsubjs - 1);
   }
 
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nfeats; j++){
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nfeats; j++){
       if(i == (ivar - 1) || j == (ivar - 1)){
 
         // Set rho = 0 when ivar is row or column
@@ -242,15 +243,15 @@ NumericMatrix rhoRcpp(NumericMatrix X,
 
 // Function for pair indexing
 // [[Rcpp::export]]
-std::vector<int> indexPairs(NumericMatrix & X,
-                            const String op = "==",
-                            const double ref = 0){
+std::vector<int32_t> indexPairs(NumericMatrix & X,
+                                const String op = "==",
+                                const double ref = 0){
 
   // Index pairs by operator and reference
-  std::vector<int> index;
-  int nfeats = X.nrow();
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  std::vector<int32_t> index;
+  int32_t nfeats = X.nrow();
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
 
       if(op == "==" || op == "="){
         if(X(i, j) == ref){
@@ -293,16 +294,16 @@ std::vector<int> indexPairs(NumericMatrix & X,
 
 // Function for pair indexing
 // [[Rcpp::export]]
-List indexToCoord(IntegerVector V, const int N){
+List indexToCoord(IntegerVector V, const int32_t N){
 
-  std::vector<int> rows;
-  std::vector<int> cols;
+  std::vector<int32_t> rows;
+  std::vector<int32_t> cols;
 
-  for(int i = 0; i < V.length(); i++){
+  for(int32_t i = 0; i < V.length(); i++){
 
-    int J = (V[i] - 1) / N + 1;
+    int32_t J = (V[i] - 1) / N + 1;
     cols.push_back(J);
-    int I = (V[i] - 1) % N + 1;
+    int32_t I = (V[i] - 1) % N + 1;
     rows.push_back(I);
   }
 
@@ -316,7 +317,7 @@ List indexToCoord(IntegerVector V, const int N){
 // [[Rcpp::export]]
 IntegerVector coordToIndex(IntegerVector row,
                            IntegerVector col,
-                           const int N){
+                           const int32_t N){
 
   IntegerVector V = (col - 1) * N + row;
   return V;
@@ -327,11 +328,11 @@ IntegerVector coordToIndex(IntegerVector row,
 NumericMatrix linRcpp(NumericMatrix & rho,
                       NumericMatrix lr){
 
-  int N = lr.nrow();
+  int32_t N = lr.nrow();
   NumericMatrix r = corRcpp(lr);
 
-  for(int i = 1; i < rho.nrow(); i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < rho.nrow(); i++){
+    for(int32_t j = 0; j < i; j++){
 
       // Calculate Z and variance of Z
       double var_ij = (1 - pow(r(i, j), 2)) * pow(rho(i, j), 2) /
@@ -351,13 +352,13 @@ NumericMatrix linRcpp(NumericMatrix & rho,
 // [[Rcpp::export]]
 NumericVector lltRcpp(NumericMatrix & X){
 
-  int nfeats = X.nrow();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.nrow();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::NumericVector result(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       result(counter) = X(i, j);
       counter += 1;
     }
@@ -370,13 +371,13 @@ NumericVector lltRcpp(NumericMatrix & X){
 // [[Rcpp::export]]
 NumericVector urtRcpp(NumericMatrix & X){
 
-  int nfeats = X.nrow();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.nrow();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::NumericVector result(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       result(counter) = X(j, i);
       counter += 1;
     }
@@ -387,15 +388,15 @@ NumericVector urtRcpp(NumericMatrix & X){
 
 // Function to label a half matrix
 // [[Rcpp::export]]
-List labRcpp(int nfeats){
+List labRcpp(int32_t nfeats){
 
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::IntegerVector partner(llt);
   Rcpp::IntegerVector pair(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       partner(counter) = i + 1;
       pair(counter) = j + 1;
       counter += 1;
@@ -412,12 +413,12 @@ List labRcpp(int nfeats){
 // [[Rcpp::export]]
 NumericMatrix half2mat(NumericVector X){
 
-  int nfeats = sqrt(2 * X.length() + .25) + .5;
+  int32_t nfeats = sqrt(2 * X.length() + .25) + .5;
   NumericMatrix A(nfeats, nfeats);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       A(i, j) = X(counter);
       A(j, i) = X(counter);
       counter += 1;
@@ -431,14 +432,14 @@ NumericMatrix half2mat(NumericVector X){
 // [[Rcpp::export]]
 NumericMatrix ratiosRcpp(NumericMatrix & X){
 
-  int nfeats = X.ncol();
-  int nsamps = X.nrow();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.ncol();
+  int32_t nsamps = X.nrow();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::NumericMatrix result(nsamps, llt);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       result(_, counter) = X(_, i) / X(_, j);
       counter += 1;
     }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -353,7 +353,7 @@ NumericMatrix linRcpp(NumericMatrix & rho,
 NumericVector lltRcpp(NumericMatrix & X){
 
   int32_t nfeats = X.nrow();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::NumericVector result(llt);
   int32_t counter = 0;
 
@@ -372,7 +372,7 @@ NumericVector lltRcpp(NumericMatrix & X){
 NumericVector urtRcpp(NumericMatrix & X){
 
   int32_t nfeats = X.nrow();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::NumericVector result(llt);
   int32_t counter = 0;
 
@@ -390,7 +390,7 @@ NumericVector urtRcpp(NumericMatrix & X){
 // [[Rcpp::export]]
 List labRcpp(int32_t nfeats){
 
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::IntegerVector partner(llt);
   Rcpp::IntegerVector pair(llt);
   int32_t counter = 0;
@@ -434,7 +434,7 @@ NumericMatrix ratiosRcpp(NumericMatrix & X){
 
   int32_t nfeats = X.ncol();
   int32_t nsamps = X.nrow();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::NumericMatrix result(nsamps, llt);
   int32_t counter = 0;
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -2,11 +2,12 @@
 #define BACKEND
 
 #include <Rcpp.h>
+#include <stdint.h>
 #include <math.h>
 
 using namespace Rcpp;
 
-NumericMatrix covRcpp(NumericMatrix & X, const int norm_type);
+NumericMatrix covRcpp(NumericMatrix & X, const int32_t norm_type);
 double wtmRcpp(NumericVector x, NumericVector w);
 double wtvRcpp(NumericVector x, NumericVector w);
 

--- a/src/ctzRcpp.cpp
+++ b/src/ctzRcpp.cpp
@@ -1,18 +1,19 @@
 #include <Rcpp.h>
+#include <stdint.h>
 using namespace Rcpp;
 
 // Function to count joint zero frequency
 // [[Rcpp::export]]
 NumericVector ctzRcpp(NumericMatrix & X){
 
-  int nfeats = X.ncol();
-  int nsubjs = X.nrow();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.ncol();
+  int32_t nsubjs = X.nrow();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
 
   // Count zero frequency per feature
   Rcpp::NumericVector zeroes(nfeats);
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nsubjs; j++){
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nsubjs; j++){
       if(X(j, i) == 0){
         zeroes(i) += 1;
       }
@@ -21,9 +22,9 @@ NumericVector ctzRcpp(NumericMatrix & X){
 
   // Count joint zero frequency
   Rcpp::NumericVector result(llt);
-  int counter = 0;
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  int32_t counter = 0;
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       result(counter) = zeroes(i) + zeroes(j);
       counter += 1;
     }

--- a/src/ctzRcpp.cpp
+++ b/src/ctzRcpp.cpp
@@ -8,7 +8,7 @@ NumericVector ctzRcpp(NumericMatrix & X){
 
   int32_t nfeats = X.ncol();
   int32_t nsubjs = X.nrow();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
 
   // Count zero frequency per feature
   Rcpp::NumericVector zeroes(nfeats);

--- a/src/deprecated.cpp
+++ b/src/deprecated.cpp
@@ -35,7 +35,7 @@ List pairmutate(NumericMatrix counts,
   // Stores log-ratio variance for each group
   int32_t nfeats = counts.ncol();
   int32_t nsubjs = counts.nrow();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   NumericVector lrv1(llt);
   NumericVector lrv2(llt);
   int32_t counter = 0;

--- a/src/deprecated.cpp
+++ b/src/deprecated.cpp
@@ -1,12 +1,13 @@
 #include <Rcpp.h>
+#include <stdint.h>
 using namespace Rcpp;
 
 // Calculates sum(LogicalVector)
 // [[Rcpp::export]]
-int count_if(LogicalVector x){
+int32_t count_if(LogicalVector x){
 
-  int counter = 0;
-  for(int i = 0; i < x.size(); i++){
+  int32_t counter = 0;
+  for(int32_t i = 0; i < x.size(); i++){
 
     if(x(i) == TRUE){
       counter++;
@@ -26,27 +27,27 @@ List pairmutate(NumericMatrix counts,
   Function sample = base["sample"];
 
   // Stores a vector of log-ratios for each group
-  int n1 = count_if(group == TRUE);
+  int32_t n1 = count_if(group == TRUE);
   NumericVector posij(n1);
-  int n2 = count_if(group != TRUE);
+  int32_t n2 = count_if(group != TRUE);
   NumericVector negij(n2);
 
   // Stores log-ratio variance for each group
-  int nfeats = counts.ncol();
-  int nsubjs = counts.nrow();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = counts.ncol();
+  int32_t nsubjs = counts.nrow();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   NumericVector lrv1(llt);
   NumericVector lrv2(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
 
       // Randomize group labels, then retrieve log-ratios
       LogicalVector grp = sample(group);
-      int posct = 0;
-      int negct = 0;
-      for(int k = 0; k < nsubjs; k++){
+      int32_t posct = 0;
+      int32_t negct = 0;
+      for(int32_t k = 0; k < nsubjs; k++){
         if(grp(k) == TRUE){
           posij(posct) = log(counts(k, i) / counts(k, j));
           posct += 1;

--- a/src/lr2propr.cpp
+++ b/src/lr2propr.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <math.h>
+#include <stdint.h>
 #include "backend.h"
 using namespace Rcpp;
 
@@ -10,17 +11,17 @@ NumericMatrix lr2vlr(NumericMatrix lr){
   // Calculate variation matrix
   NumericMatrix x = clone(lr);
   NumericMatrix X = covRcpp(x, 0);
-  int nfeats = lr.ncol();
+  int32_t nfeats = lr.ncol();
 
   // Find diagonal
   NumericVector diag(nfeats);
-  for(int j = 0; j < nfeats; j++){
+  for(int32_t j = 0; j < nfeats; j++){
     diag[j] = X(j, j);
   }
 
   // Calculate vlr
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nfeats; j++){
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nfeats; j++){
       X(i, j) = -2 * X(i, j) + diag[i] + diag[j];
     }
   }
@@ -35,10 +36,10 @@ NumericMatrix lr2phi(NumericMatrix lr){
   // Make vlr from log-ratio data
   NumericMatrix x = clone(lr);
   NumericMatrix mat = lr2vlr(x);
-  int nsubjs = lr.nrow();
+  int32_t nsubjs = lr.nrow();
 
   // Calculate phi = vlr[i, j] / var[, i]
-  for(int i = 0; i < mat.ncol(); i++){
+  for(int32_t i = 0; i < mat.ncol(); i++){
 
     double vari = sum(pow(lr(_, i) - mean(lr(_, i)), 2.0)) / (nsubjs - 1);
     mat(_, i) = mat(_, i) / vari;
@@ -55,19 +56,19 @@ NumericMatrix lr2rho(NumericMatrix lr){
   // Make vlr from log-ratio data
   NumericMatrix x = clone(lr);
   NumericMatrix mat = lr2vlr(x);
-  int nsubjs = lr.nrow();
-  int nfeats = lr.ncol();
+  int32_t nsubjs = lr.nrow();
+  int32_t nfeats = lr.ncol();
 
   // Calculate variance of the i-th lr composition
   NumericVector vars(nfeats);
-  for(int i = 0; i < nfeats; i++){
+  for(int32_t i = 0; i < nfeats; i++){
 
     vars[i] = sum(pow(lr(_, i) - mean(lr(_, i)), 2.0)) / (nsubjs - 1);
   }
 
   // Calculate rho = 1 - vlr[i, j] / (var[, i] + var[, j])
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nfeats; j++){
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nfeats; j++){
 
       if(i == j){
         mat(i, j) = 1; // Force diagonal = 1
@@ -86,9 +87,9 @@ NumericMatrix lr2phs(NumericMatrix lr){
 
   // Calculate phs = (1 - rho) / (1 + rho)
   NumericMatrix mat = lr2rho(lr);
-  int nfeats = mat.ncol();
-  for(int i = 0; i < nfeats; i++){
-    for(int j = 0; j < nfeats; j++){
+  int32_t nfeats = mat.ncol();
+  for(int32_t i = 0; i < nfeats; i++){
+    for(int32_t j = 0; j < nfeats; j++){
 
       if(i == j){
         mat(i, j) = 0; // Force diagonal = 0

--- a/src/lrm.cpp
+++ b/src/lrm.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <math.h>
+#include <stdint.h>
 #include "backend.h"
 using namespace Rcpp;
 
@@ -14,10 +15,10 @@ NumericVector lrm(NumericMatrix & Y,
 
   // Output a half-matrix
   NumericMatrix X = clone(Y);
-  int nfeats = X.ncol();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.ncol();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   NumericVector result(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
   if(!R_IsNA(a)){ // Weighted and non-weighted, alpha-transformed
 
@@ -30,17 +31,17 @@ NumericVector lrm(NumericMatrix & Y,
     }
 
     // Raise all of X to the a power
-    for(int i = 0; i < X.nrow(); i++){
-      for(int j = 0; j < X.ncol(); j++){
+    for(int32_t i = 0; i < X.nrow(); i++){
+      for(int32_t j = 0; j < X.ncol(); j++){
         X(i, j) = pow(X(i, j), a);
       }
     }
 
     // Raise all of Xfull to the a power
     NumericMatrix Xfull = clone(Yfull);
-    int fullfeats = Xfull.ncol();
-    for(int i = 0; i < Xfull.nrow(); i++){
-      for(int j = 0; j < Xfull.ncol(); j++){
+    int32_t fullfeats = Xfull.ncol();
+    for(int32_t i = 0; i < Xfull.nrow(); i++){
+      for(int32_t j = 0; j < Xfull.ncol(); j++){
         Xfull(i, j) = pow(Xfull(i, j), a);
       }
     }
@@ -64,8 +65,8 @@ NumericVector lrm(NumericMatrix & Y,
       Rcpp::NumericVector Xjscaled(nfeats);
       Rcpp::NumericVector Xz(nfeats);
       Rcpp::NumericVector Xfullz(fullfeats);
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Wij = W(_, i) * W(_, j);
           Wfullij = Wfull(_, i) * Wfull(_, j);
           Xiscaled = X(_, i) / wtmRcpp(Xfull(_, i), Wfullij);
@@ -88,8 +89,8 @@ NumericVector lrm(NumericMatrix & Y,
       Rcpp::NumericVector Xfullz(fullfeats);
       double N1 = X.nrow();
       double NT = Xfull.nrow();
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Xz = X(_, i) - X(_, j);
           Xfullz = Xfull(_, i) - Xfull(_, j);
           double Mz = mean(X(_, i) / mean(Xfull(_, i)) - mean(X(_, j) / mean(Xfull(_, j))));
@@ -107,8 +108,8 @@ NumericVector lrm(NumericMatrix & Y,
     if(weighted){
 
       Rcpp::NumericVector Wij(nfeats);
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Wij = W(_, i) * W(_, j);
           result(counter) = wtmRcpp(log(X(_, i) / X(_, j)), Wij);
           counter += 1;
@@ -117,8 +118,8 @@ NumericVector lrm(NumericMatrix & Y,
 
     }else{
 
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           result(counter) = mean(log(X(_, i) / X(_, j)));
           counter += 1;
         }

--- a/src/lrm.cpp
+++ b/src/lrm.cpp
@@ -16,7 +16,7 @@ NumericVector lrm(NumericMatrix & Y,
   // Output a half-matrix
   NumericMatrix X = clone(Y);
   int32_t nfeats = X.ncol();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   NumericVector result(llt);
   int32_t counter = 0;
 

--- a/src/lrv.cpp
+++ b/src/lrv.cpp
@@ -16,7 +16,7 @@ NumericVector lrv(NumericMatrix & Y,
   // Output a half-matrix
   NumericMatrix X = clone(Y);
   int32_t nfeats = X.ncol();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   NumericVector result(llt);
   int32_t counter = 0;
 

--- a/src/lrv.cpp
+++ b/src/lrv.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <math.h>
+#include <stdint.h>
 #include "backend.h"
 using namespace Rcpp;
 
@@ -14,10 +15,10 @@ NumericVector lrv(NumericMatrix & Y,
 
   // Output a half-matrix
   NumericMatrix X = clone(Y);
-  int nfeats = X.ncol();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = X.ncol();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   NumericVector result(llt);
-  int counter = 0;
+  int32_t counter = 0;
 
   if(!R_IsNA(a)){ // Weighted and non-weighted, alpha-transformed
 
@@ -30,17 +31,17 @@ NumericVector lrv(NumericMatrix & Y,
     }
 
     // Raise all of X to the a power
-    for(int i = 0; i < X.nrow(); i++){
-      for(int j = 0; j < X.ncol(); j++){
+    for(int32_t i = 0; i < X.nrow(); i++){
+      for(int32_t j = 0; j < X.ncol(); j++){
         X(i, j) = pow(X(i, j), a);
       }
     }
 
     // Raise all of Xfull to the a power
     NumericMatrix Xfull = clone(Yfull);
-    int fullfeats = Xfull.ncol();
-    for(int i = 0; i < Xfull.nrow(); i++){
-      for(int j = 0; j < Xfull.ncol(); j++){
+    int32_t fullfeats = Xfull.ncol();
+    for(int32_t i = 0; i < Xfull.nrow(); i++){
+      for(int32_t j = 0; j < Xfull.ncol(); j++){
         Xfull(i, j) = pow(Xfull(i, j), a);
       }
     }
@@ -64,8 +65,8 @@ NumericVector lrv(NumericMatrix & Y,
       Rcpp::NumericVector Wfullij(fullfeats);
       Rcpp::NumericVector Xiscaled(nfeats);
       Rcpp::NumericVector Xjscaled(nfeats);
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Wij = W(_, i) * W(_, j);
           Wfullij = Wfull(_, i) * Wfull(_, j);
           Xiscaled = (X(_, i) - wtmRcpp(X(_, i), Wij)) / wtmRcpp(Xfull(_, i), Wfullij);
@@ -84,8 +85,8 @@ NumericVector lrv(NumericMatrix & Y,
       Rcpp::NumericVector Xiscaled(nfeats);
       Rcpp::NumericVector Xjscaled(nfeats);
       double N1 = X.nrow();
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Xiscaled = (X(_, i) - mean(X(_, i))) / mean(Xfull(_, i));
           Xjscaled = (X(_, j) - mean(X(_, j))) / mean(Xfull(_, j));
           result(counter) = sum(pow(Xiscaled - Xjscaled, 2)) /
@@ -100,8 +101,8 @@ NumericVector lrv(NumericMatrix & Y,
     if(weighted){
 
       Rcpp::NumericVector Wij(nfeats);
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           Wij = W(_, i) * W(_, j);
           result(counter) = wtvRcpp(log(X(_, i) / X(_, j)), Wij);
           counter += 1;
@@ -110,8 +111,8 @@ NumericVector lrv(NumericMatrix & Y,
 
     }else{
 
-      for(int i = 1; i < nfeats; i++){
-        for(int j = 0; j < i; j++){
+      for(int32_t i = 1; i < nfeats; i++){
+        for(int32_t j = 0; j < i; j++){
           result(counter) = var(log(X(_, i) / X(_, j)));
           counter += 1;
         }

--- a/src/omega.cpp
+++ b/src/omega.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 NumericVector omega(NumericMatrix & W){
 
   int32_t nfeats = W.ncol();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::NumericVector result(llt);
   Rcpp::NumericVector Wij(nfeats);
   int32_t counter = 0;
@@ -30,7 +30,7 @@ NumericVector omega(NumericMatrix & W){
 NumericVector Omega(NumericMatrix & W){
 
   int32_t nfeats = W.ncol();
-  int32_t llt = nfeats * (nfeats - 1) / 2;
+  int32_t llt = (nfeats / 2) * (nfeats - 1);
   Rcpp::NumericVector result(llt);
   Rcpp::NumericVector Wij(nfeats);
   int32_t counter = 0;

--- a/src/omega.cpp
+++ b/src/omega.cpp
@@ -1,19 +1,20 @@
 #include <Rcpp.h>
+#include <stdint.h>
 using namespace Rcpp;
 
 // Calculate lrv weight modifier
 // [[Rcpp::export]]
 NumericVector omega(NumericMatrix & W){
 
-  int nfeats = W.ncol();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = W.ncol();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::NumericVector result(llt);
   Rcpp::NumericVector Wij(nfeats);
-  int counter = 0;
+  int32_t counter = 0;
   double n = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       Wij = W(_, i) * W(_, j);
       n = sum(Wij);
       result(counter) = n - sum(pow(Wij, 2)) / n;
@@ -28,14 +29,14 @@ NumericVector omega(NumericMatrix & W){
 // [[Rcpp::export]]
 NumericVector Omega(NumericMatrix & W){
 
-  int nfeats = W.ncol();
-  int llt = nfeats * (nfeats - 1) / 2;
+  int32_t nfeats = W.ncol();
+  int32_t llt = nfeats * (nfeats - 1) / 2;
   Rcpp::NumericVector result(llt);
   Rcpp::NumericVector Wij(nfeats);
-  int counter = 0;
+  int32_t counter = 0;
 
-  for(int i = 1; i < nfeats; i++){
-    for(int j = 0; j < i; j++){
+  for(int32_t i = 1; i < nfeats; i++){
+    for(int32_t j = 0; j < i; j++){
       Wij = W(_, i) * W(_, j);
       result(counter) = sum(Wij);
       counter += 1;


### PR DESCRIPTION
Replacing `int` declarations with `int32_t` and refactoring integer arithmetic operations to avoid overflows in intermediate results. This PR addresses issue https://github.com/tpq/propr/issues/13