### PR TITLE
Add Rcpp counting functions

### DIFF
--- a/R/2-proprCall.R
+++ b/R/2-proprCall.R
@@ -177,9 +177,9 @@ updateCutoffs.propr <- function(object, cutoff, ncores){
     # Find number of permuted theta less than cutoff
     sapply(FDR$cutoff, function(cut){
       if(object@metric == "rho" | object@metric == "cor"){
-        sum(pkt > cut)
+        count_greater_than(pkt, cut)
       }else{ # phi & phs
-        sum(pkt < cut)
+        count_less_than(pkt, cut)
       }
     })
   }
@@ -245,9 +245,9 @@ updateCutoffs.propr <- function(object, cutoff, ncores){
 
         # Count positives as rho > cutoff, cor > cutoff, phi < cutoff, phs < cutoff
         if(object@metric == "rho" | object@metric == "cor"){
-          FDR[cut, "randcounts"] <- FDR[cut, "randcounts"] + sum(pkt > FDR[cut, "cutoff"])
+          FDR[cut, "randcounts"] <- FDR[cut, "randcounts"] + count_greater_than(pkt, FDR[cut, "cutoff"])
         }else{ # phi & phs
-          FDR[cut, "randcounts"] <- FDR[cut, "randcounts"] + sum(pkt < FDR[cut, "cutoff"])
+          FDR[cut, "randcounts"] <- FDR[cut, "randcounts"] + count_less_than(pkt, FDR[cut, "cutoff"])
         }
       }
     }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,6 +77,14 @@ ratiosRcpp <- function(X) {
     .Call(`_propr_ratiosRcpp`, X)
 }
 
+count_less_than <- function(x, cutoff) {
+    .Call(`_propr_count_less_than`, x, cutoff)
+}
+
+count_greater_than <- function(x, cutoff) {
+    .Call(`_propr_count_greater_than`, x, cutoff)
+}
+
 ctzRcpp <- function(X) {
     .Call(`_propr_ctzRcpp`, X)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -227,6 +227,30 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// count_less_than
+int count_less_than(NumericVector x, double cutoff);
+RcppExport SEXP _propr_count_less_than(SEXP xSEXP, SEXP cutoffSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< double >::type cutoff(cutoffSEXP);
+    rcpp_result_gen = Rcpp::wrap(count_less_than(x, cutoff));
+    return rcpp_result_gen;
+END_RCPP
+}
+// count_greater_than
+int count_greater_than(NumericVector x, double cutoff);
+RcppExport SEXP _propr_count_greater_than(SEXP xSEXP, SEXP cutoffSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< double >::type cutoff(cutoffSEXP);
+    rcpp_result_gen = Rcpp::wrap(count_greater_than(x, cutoff));
+    return rcpp_result_gen;
+END_RCPP
+}
 // ctzRcpp
 NumericVector ctzRcpp(NumericMatrix& X);
 RcppExport SEXP _propr_ctzRcpp(SEXP XSEXP) {
@@ -380,6 +404,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_propr_labRcpp", (DL_FUNC) &_propr_labRcpp, 1},
     {"_propr_half2mat", (DL_FUNC) &_propr_half2mat, 1},
     {"_propr_ratiosRcpp", (DL_FUNC) &_propr_ratiosRcpp, 1},
+    {"_propr_count_less_than", (DL_FUNC) &_propr_count_less_than, 2},
+    {"_propr_count_greater_than", (DL_FUNC) &_propr_count_greater_than, 2},
     {"_propr_ctzRcpp", (DL_FUNC) &_propr_ctzRcpp, 1},
     {"_propr_count_if", (DL_FUNC) &_propr_count_if, 1},
     {"_propr_pairmutate", (DL_FUNC) &_propr_pairmutate, 2},

--- a/src/comparison.cpp
+++ b/src/comparison.cpp
@@ -1,0 +1,38 @@
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// Count the number of elements in vector `x` that are strictly less than the
+// `cutoff`.
+//
+// [[Rcpp::export]]
+int count_less_than(NumericVector x, double cutoff) {
+  // See `?Memory-limits`: R vectors are limited in size to the max value of a
+  // signed int, as they use signed int for their size.  If all values of `x`
+  // are greater than cutoff, then we would get a count of INT_MAX, so the count
+  // shouldn't overflow.
+  int count = 0;
+  int len = x.size();
+
+  for (int i = 0; i < len; ++i) {
+    // Returns 1 if it's less than cutoff, zero otherwise.  Add it to the count.
+    count += x[i] < cutoff;
+  }
+
+  return count;
+}
+
+// Count the number of elements in vector `x` that are strictly greater than the
+// `cutoff`.
+//
+// [[Rcpp::export]]
+int count_greater_than(NumericVector x, double cutoff) {
+  int count = 0;
+  int len = x.size();
+
+  for (int i = 0; i < len; ++i) {
+    // Returns 1 if it's less than cutoff, zero otherwise.  Add it to the count.
+    count += x[i] > cutoff;
+  }
+
+  return count;
+}

--- a/tests/testthat/test-comparison.R
+++ b/tests/testthat/test-comparison.R
@@ -1,0 +1,17 @@
+# This is the reference implementation to test against.
+ref_impl <- function(values, cutoff, comp_fn) {
+  sum(comp_fn(values, cutoff))
+}
+
+niters <- 100
+
+test_that("count_less_than works", {
+  # This is a ad-hoc property test, without needing to pull in another dependency.
+  for (i in 1:niters) {
+    vals <- runif(10, -1, 1)
+    cutoff <- runif(1, -1, 1)
+
+    expect_equal(count_less_than(vals, cutoff), ref_impl(vals, cutoff, `<`))
+    expect_equal(count_greater_than(vals, cutoff), ref_impl(vals, cutoff, `>`))
+  }
+})


### PR DESCRIPTION
Here's another speed-up of the `updateCutoffs` function.

The next biggest bottleneck after the `p=0` thing (see #27 & #28) was in summing the number of `pkt` less than or greater than the cutoff.  To be precise, the most time taken in that was actually the boolean comparisons.  The more taxa, the more comparisons you must do.  

I should say that this issue doesn't show up with the default argument to `cutoffs` as the default is a vector of 3 values.  But often, I want to pass in cutoffs of length 100 (or more) so I can make a cute chart showing how the FDR changes over a range of cutoffs.  In these cases, `updateCutoffs` gets pretty slow.

This change goes well with the `p=0` change from #28.  This change makes less of a difference without `p=0` change.

It's a decent speed up...not huge, but not bad.  It does introduce more Rcpp code, though, so you can balance whether you think it is worth it.

## Timings

The data was:

* Num. samples = 25
* Num taxa: 100-800
* `cutoff = seq(0.01, 1, 0.01)` (that's length of 100)

![orig](https://user-images.githubusercontent.com/3172014/138368025-54829190-658c-4b27-a430-589491688ae0.png)

![with_p_0](https://user-images.githubusercontent.com/3172014/138368023-53a64c6e-7b0d-492b-b47f-3a9ba75e9a3a.png)

![with_p_0_and_rcpp_counting](https://user-images.githubusercontent.com/3172014/138368021-6161a750-59ae-4099-b60a-ab395cf7b66f.png)

It's a modest speed up.

## Tests

I added tests as well to check that the new Rcpp functions matched a pure-R implementation.