### PR TITLE
Fix select argument handling for vector input

### DIFF
--- a/R/1-propr.R
+++ b/R/1-propr.R
@@ -113,11 +113,16 @@ propr <- function(counts,
   ### OPTIONALLY REDUCE DATA SIZE BEFORE COMPUTING MATRIX
   ##############################################################################
 
-  if (!is.na(select)) {
+  if (length(select) == 1 && is.na(select)) {
+    # Do nothing - no output, no return value
+    invisible(NULL)
+  } else if (is.vector(select) && length(select) > 0) {
     message("Alert: Using 'select' may make permutation testing unreliable.")
-    counts <- counts[, select]
+    counts <- counts[, select, drop = FALSE]
     ct <- ct[, select]
     lr <- lr[, select]
+  } else {
+    stop("Error: 'select' must be NA or a vector of indices.")
   }
 
   ##############################################################################


### PR DESCRIPTION
This pull request addresses an issue in the handling of the select argument when reducing data size before computing the matrix. The original code assumed select was always a singular value, causing an error with the if statement when select was a vector of indices.
Issue: #66 