### PR TITLE
propd: change updateF to get prior variance from ratio-wise trend and…

### DIFF
--- a/man/propd.Rd
+++ b/man/propd.Rd
@@ -30,7 +30,7 @@ setEmergent(propd)
 
 setActive(propd, what = "theta_d")
 
-updateF(propd, moderated = FALSE, ivar = "clr")
+updateF(propd, moderated = TRUE, ivar = "clr")
 }
 \arguments{
 \item{object}{A \code{propd} object.}
@@ -61,6 +61,10 @@ should be performed.}
 whether to calculate a moderated F-statistic.}
 
 \item{ivar}{See \code{propr} method.}
+
+\item{moderated_trend}{For \code{updateF}, a boolean. Toggles
+whether to incorporate mean-variance trend in the moderated 
+F-statistic. Default is FALSE.}
 }
 \value{
 A \code{propd} object containing the computed theta values,

--- a/tests/testthat/test-PROPD-theta.R
+++ b/tests/testthat/test-PROPD-theta.R
@@ -53,11 +53,19 @@ test_that("active theta_e matches calculation using theta_d", {
   # when weighted
   groups <- lapply(unique(group), function(g) g == group)
   ngrp <- length(unique(group))
-  # calculate weights
+  # calculate weights, now according to sample reliability weights from limma
   design <-
     stats::model.matrix(~ . + 0, data = as.data.frame(group))
-  v <- limma::voom(t(pd@counts), design = design)
-  W <- t(v$weights)
+
+  logX <- log(pd@counts)
+  z.geo = rowMeans(logX)
+  z.lr = as.matrix(sweep(logX, 1, z.geo, "-"))
+  lz.sr = t(z.lr + mean(z.geo)) #corresponds to log(z.sr) in updateF function
+
+  #use quality weights from limma:
+  aw = limma::arrayWeights(lz.sr, design) 
+  W = t(sweep(matrix(1, nrow(lz.sr), ncol(lz.sr)), 2, aw, `*`)) #get the correct dimensions
+  
   ps <- lapply(groups, function(g) propr:::omega(W[g,]))
   names(ps) <- paste0("p", 1:ngrp)
   p <- propr:::omega(W)

--- a/tests/testthat/test-PROPD-weight.R
+++ b/tests/testthat/test-PROPD-weight.R
@@ -1,6 +1,19 @@
 library(testthat)
 library(propr)
 
+fetch_weights=function(counts,design){
+    #this function calculates the new default weights, i.e., sample reliability weights using limma
+    logX <- log(counts)
+    z.geo = rowMeans(logX)
+    z.lr = as.matrix(sweep(logX, 1, z.geo, "-"))
+    lz.sr = t(z.lr + mean(z.geo)) #corresponds to log(z.sr) in updateF function
+
+    #use quality weights from limma:
+    aw = limma::arrayWeights(lz.sr, design) 
+    W = t(sweep(matrix(1, nrow(lz.sr), ncol(lz.sr)), 2, aw, `*`)) #get the correct dimensions
+    return(W)
+}  
+
 # data
 keep <- iris$Species %in% c("setosa", "versicolor")
 counts <- iris[keep, 1:4] * 10
@@ -8,11 +21,11 @@ group <- ifelse(iris[keep, "Species"] == "setosa", "A", "B")
 
 test_that("test that providing weights to propd works", {
 
-    # get weights
+    # get weights, now using sample reliability weights fron limma:
     design <- stats::model.matrix(~ . + 0, data = as.data.frame(group))
-    v <- limma::voom(t(counts), design = design)
-    W <- t(v$weights)
-
+ 
+    W=fetch_weights(counts,design)
+    
     # calculate propr 
     pd_w <- propd(counts, group, weighted = TRUE)
     pd_w2 <- propd(counts, group, weighted = TRUE, weights = W)
@@ -25,8 +38,7 @@ test_that("test that weights are properly incorporated to lrv", {
 
     # get weights
     design <- stats::model.matrix(~ . + 0, data = as.data.frame(group))
-    v <- limma::voom(t(counts), design = design)
-    W <- t(v$weights)
+    W=fetch_weights(counts,design)
 
     # calculate lrv using propr
     counts <- as.matrix(counts)
@@ -52,8 +64,7 @@ test_that("test that weights are properly incorporated to lrv", {
 test_that("test that weights are properly incorporated to lrm", {
     # get weights
     design <- stats::model.matrix(~ . + 0, data = as.data.frame(group))
-    v <- limma::voom(t(counts), design = design)
-    W <- t(v$weights)
+    W=fetch_weights(counts,design)
 
     # calculate lrm using propr
     counts <- as.matrix(counts)
@@ -76,8 +87,7 @@ test_that("test that weights are properly incorporated to lrm", {
 test_that("test that weights are properly incorporated to omega" ,{
     # get weights
     design <- stats::model.matrix(~ . + 0, data = as.data.frame(group))
-    v <- limma::voom(t(counts), design = design)
-    W <- t(v$weights)
+    W=fetch_weights(counts,design)
 
     # calculate omega using propr
     counts <- as.matrix(counts)
@@ -98,8 +108,7 @@ test_that("test that weights are properly incorporated to omega" ,{
 test_that("test that weights are properly incorporated to theta", {
     # get weights
     design <- stats::model.matrix(~ . + 0, data = as.data.frame(group))
-    v <- limma::voom(t(counts), design = design)
-    W <- t(v$weights)
+    W=fetch_weights(counts,design)
 
     # calculate theta using propr
     counts <- as.matrix(counts)


### PR DESCRIPTION
The function updateF in 2b-propd-frontend.R was modified to calculate a prior variance for each ratio based on the mean-variance trend for ratios (for the moderated F statistic). In the function calculate_theta in 2a-propd-backend.R, precision weights for weighted=TRUE were replaced by sample reliability weights from the Limma package. (Both changes have improved the subsampling and downsampling benchmarks.)